### PR TITLE
fix: REVLoans mixed-decimal normalization, liquidation boundary, and …

### DIFF
--- a/src/REVLoans.sol
+++ b/src/REVLoans.sol
@@ -422,7 +422,13 @@ contract REVLoans is ERC721, ERC2771Context, Ownable, IREVLoans {
         return ERC2771Context._msgSender();
     }
 
-    /// @notice The total borrowed amount from a revnet.
+    /// @notice The total borrowed amount from a revnet, aggregated across all loan sources.
+    /// @dev Each source's `totalBorrowedFrom` is stored in the source token's native decimals (e.g. 6 for USDC,
+    /// 18 for ETH). Before aggregation, each amount is normalized to the target `decimals` to prevent mixed-decimal
+    /// arithmetic errors. For cross-currency sources, the normalized amount is then converted via the price feed.
+    /// @dev Callers should ensure the price feed has sufficient precision for the target `decimals`. Inverse price
+    /// feeds may truncate to zero at low decimal counts (e.g. a feed returning 1e21 at 6 decimals inverts to
+    /// mulDiv(1e6, 1e6, 1e21) = 0), which would cause a division-by-zero in the price conversion.
     /// @param revnetId The ID of the revnet to check for borrowed assets from.
     /// @param decimals The decimals the resulting fixed point value will include.
     /// @param currency The currency the resulting value will be in terms of.
@@ -620,6 +626,8 @@ contract REVLoans is ERC721, ERC2771Context, Ownable, IREVLoans {
     /// @notice Refinances a loan by transferring extra collateral from an existing loan to a new loan.
     /// @dev Useful if a loan's collateral has gone up in value since the loan was created.
     /// @dev Refinancing a loan will burn the original and create two new loans.
+    /// @dev This function is intentionally not payable — it only moves existing collateral between loans and does
+    /// not accept new funds. Any ETH sent with the call will be rejected by the EVM.
     /// @param loanId The ID of the loan to reallocate collateral from.
     /// @param collateralCountToTransfer The amount of collateral to transfer from the original loan.
     /// @param source The source of the loan to create.

--- a/src/REVLoans.sol
+++ b/src/REVLoans.sol
@@ -381,8 +381,8 @@ contract REVLoans is ERC721, ERC2771Context, Ownable, IREVLoans {
         // If the loan period has passed the prepaid time frame, take a fee.
         if (timeSinceLoanCreated <= loan.prepaidDuration) return 0;
 
-        // If the loan period has passed the liqidation time frame, do not allow loan management.
-        if (timeSinceLoanCreated > LOAN_LIQUIDATION_DURATION) {
+        // If the loan period has reached or passed the liquidation time frame, do not allow loan management.
+        if (timeSinceLoanCreated >= LOAN_LIQUIDATION_DURATION) {
             revert REVLoans_LoanExpired(timeSinceLoanCreated, LOAN_LIQUIDATION_DURATION);
         }
 
@@ -448,20 +448,36 @@ contract REVLoans is ERC721, ERC2771Context, Ownable, IREVLoans {
             JBAccountingContext memory accountingContext =
                 source.terminal.accountingContextForTokenOf({projectId: revnetId, token: source.token});
 
-            // Normalize the price to the provided currency and decimals.
-            uint256 pricePerUnit = accountingContext.currency == currency
-                ? 10 ** decimals
-                : PRICES.pricePerUnitOf({
+            // Get a reference to the amount of tokens loaned out.
+            uint256 tokensLoaned = totalBorrowedFrom[revnetId][source.terminal][source.token];
+
+            // Skip if no tokens are loaned from this source.
+            if (tokensLoaned == 0) continue;
+
+            // Normalize the token amount from the source's decimals to the target decimals.
+            uint256 normalizedTokens;
+            if (accountingContext.decimals > decimals) {
+                normalizedTokens = tokensLoaned / (10 ** (accountingContext.decimals - decimals));
+            } else if (accountingContext.decimals < decimals) {
+                normalizedTokens = tokensLoaned * (10 ** (decimals - accountingContext.decimals));
+            } else {
+                normalizedTokens = tokensLoaned;
+            }
+
+            // If the currency matches, add the normalized amount directly.
+            if (accountingContext.currency == currency) {
+                borrowedAmount += normalizedTokens;
+            } else {
+                // Otherwise, convert via the price feed.
+                uint256 pricePerUnit = PRICES.pricePerUnitOf({
                     projectId: revnetId,
                     pricingCurrency: accountingContext.currency,
                     unitCurrency: currency,
                     decimals: decimals
                 });
 
-            // Get a reference to the amount of tokens loaned out.
-            uint256 tokensLoaned = totalBorrowedFrom[revnetId][source.terminal][source.token];
-
-            borrowedAmount += mulDiv(tokensLoaned, 10 ** decimals, pricePerUnit);
+                borrowedAmount += mulDiv(normalizedTokens, 10 ** decimals, pricePerUnit);
+            }
         }
     }
 
@@ -626,12 +642,14 @@ contract REVLoans is ERC721, ERC2771Context, Ownable, IREVLoans {
         uint256 prepaidFeePercent
     )
         external
-        payable
         override
         returns (uint256 reallocatedLoanId, uint256 newLoanId, REVLoan memory reallocatedLoan, REVLoan memory newLoan)
     {
         // Make sure only the loan's owner can manage it.
         if (_ownerOf(loanId) != _msgSender()) revert REVLoans_Unauthorized(_msgSender(), _ownerOf(loanId));
+
+        // Make sure no ETH is sent — this function does not accept native tokens.
+        if (msg.value != 0) revert REVLoans_NoMsgValueAllowed();
 
         // Keep a reference to the revnet ID of the loan being reallocated.
         uint256 revnetId = revnetIdOfLoanWith(loanId);

--- a/src/REVLoans.sol
+++ b/src/REVLoans.sol
@@ -648,8 +648,7 @@ contract REVLoans is ERC721, ERC2771Context, Ownable, IREVLoans {
         // Make sure only the loan's owner can manage it.
         if (_ownerOf(loanId) != _msgSender()) revert REVLoans_Unauthorized(_msgSender(), _ownerOf(loanId));
 
-        // Make sure no ETH is sent — this function does not accept native tokens.
-        if (msg.value != 0) revert REVLoans_NoMsgValueAllowed();
+        // Note: this function is not payable, so the EVM prevents sending ETH at the call level.
 
         // Keep a reference to the revnet ID of the loan being reallocated.
         uint256 revnetId = revnetIdOfLoanWith(loanId);

--- a/src/interfaces/IREVLoans.sol
+++ b/src/interfaces/IREVLoans.sol
@@ -124,7 +124,6 @@ interface IREVLoans {
         uint256 prepaidFeePercent
     )
         external
-        payable
         returns (uint256 reallocatedLoanId, uint256 newLoanId, REVLoan memory reallocatedLoan, REVLoan memory newLoan);
     function setTokenUriResolver(IJBTokenUriResolver resolver) external;
 }

--- a/test/TestPR32_MixedFixes.t.sol
+++ b/test/TestPR32_MixedFixes.t.sol
@@ -224,4 +224,159 @@ contract TestPR32_MixedFixes is TestBaseWorkflow, JBTest {
         assertTrue(reallocatedLoanId != 0, "Reallocated loan should exist");
         assertTrue(newLoanId != 0, "New loan should exist");
     }
+
+    // ==================== Mixed-Decimal Normalization Tests ====================
+
+    uint256 MIXED_REVNET_ID;
+
+    /// @notice Deploy a revnet with BOTH ETH (18 dec) and TOKEN (6 dec) as loan sources.
+    function _deployMixedDecimalRevnet() internal {
+        JBAccountingContext[] memory acc = new JBAccountingContext[](2);
+        acc[0] = JBAccountingContext({token: JBConstants.NATIVE_TOKEN, decimals: 18, currency: uint32(uint160(JBConstants.NATIVE_TOKEN))});
+        acc[1] = JBAccountingContext({token: address(TOKEN), decimals: 6, currency: uint32(uint160(address(TOKEN)))});
+        JBTerminalConfig[] memory tc = new JBTerminalConfig[](1);
+        tc[0] = JBTerminalConfig({terminal: jbMultiTerminal(), accountingContextsToAccept: acc});
+        REVStageConfig[] memory stages = new REVStageConfig[](1);
+        JBSplit[] memory splits = new JBSplit[](1);
+        splits[0].beneficiary = payable(multisig());
+        splits[0].percent = 10_000;
+        REVAutoIssuance[] memory ai = new REVAutoIssuance[](1);
+        ai[0] = REVAutoIssuance({chainId: uint32(block.chainid), count: uint104(70_000e18), beneficiary: multisig()});
+        // cashOutTaxRate=0 for proportional math (simpler assertions).
+        stages[0] = REVStageConfig({startsAtOrAfter: uint40(block.timestamp), autoIssuances: ai, splitPercent: 2000, splits: splits, initialIssuance: uint112(1000e18), issuanceCutFrequency: 90 days, issuanceCutPercent: JBConstants.MAX_WEIGHT_CUT_PERCENT / 2, cashOutTaxRate: 0, extraMetadata: 0});
+        REVLoanSource[] memory ls = new REVLoanSource[](2);
+        ls[0] = REVLoanSource({token: JBConstants.NATIVE_TOKEN, terminal: jbMultiTerminal()});
+        ls[1] = REVLoanSource({token: address(TOKEN), terminal: jbMultiTerminal()});
+        REVConfig memory cfg = REVConfig({description: REVDescription("Mixed", "$MIX", "ipfs://mix", "MIX_TOKEN"), baseCurrency: uint32(uint160(JBConstants.NATIVE_TOKEN)), splitOperator: multisig(), stageConfigurations: stages, loanSources: ls, loans: address(LOANS_CONTRACT)});
+        REVBuybackHookConfig memory bbh = REVBuybackHookConfig({dataHook: IJBRulesetDataHook(address(0)), hookToConfigure: IJBBuybackHook(address(0)), poolConfigurations: new REVBuybackPoolConfig[](0)});
+        MIXED_REVNET_ID = REV_DEPLOYER.deployFor({revnetId: 0, configuration: cfg, terminalConfigurations: tc, buybackHookConfiguration: bbh, suckerDeploymentConfiguration: REVSuckerDeploymentConfig({deployerConfigurations: new JBSuckerDeployerConfig[](0), salt: keccak256("MIXED")})});
+    }
+
+    /// @notice When only the ETH source has borrows, TOKEN source (0 borrowed) should be skipped via `continue`.
+    /// @dev Exercises the `if (tokensLoaned == 0) continue` path in _totalBorrowedFrom.
+    function test_mixedDecimals_zeroBorrowFromTokenSource_continuePath() public {
+        _deployMixedDecimalRevnet();
+
+        // Pay ETH to get project tokens.
+        vm.prank(USER);
+        uint256 tokenCount = jbMultiTerminal().pay{value: 10e18}(MIXED_REVNET_ID, JBConstants.NATIVE_TOKEN, 10e18, USER, 0, "", "");
+
+        // Borrow from ETH source.
+        uint256 borrowable = LOANS_CONTRACT.borrowableAmountFrom(MIXED_REVNET_ID, tokenCount, 18, uint32(uint160(JBConstants.NATIVE_TOKEN)));
+        require(borrowable > 0, "Must have borrowable amount");
+
+        mockExpect(address(jbPermissions()), abi.encodeCall(IJBPermissions.hasPermission, (address(LOANS_CONTRACT), USER, MIXED_REVNET_ID, 10, true, true)), abi.encode(true));
+        REVLoanSource memory ethSource = REVLoanSource({token: JBConstants.NATIVE_TOKEN, terminal: jbMultiTerminal()});
+        vm.prank(USER);
+        (uint256 loanId, REVLoan memory loan) = LOANS_CONTRACT.borrowFrom(MIXED_REVNET_ID, ethSource, 0, tokenCount, payable(USER), 25);
+
+        // Verify loan created and TOKEN source has zero borrowed.
+        assertTrue(loanId != 0, "ETH loan should be created");
+        assertTrue(loan.amount > 0, "Loan amount should be nonzero");
+        assertEq(LOANS_CONTRACT.totalBorrowedFrom(MIXED_REVNET_ID, jbMultiTerminal(), address(TOKEN)), 0, "TOKEN source should have zero borrowed");
+        assertTrue(LOANS_CONTRACT.totalBorrowedFrom(MIXED_REVNET_ID, jbMultiTerminal(), JBConstants.NATIVE_TOKEN) > 0, "ETH source should have nonzero borrowed");
+    }
+
+    /// @notice Borrow from TOKEN (6-decimal) source, verify totalBorrowed tracked and borrowable works in 18-dec context.
+    /// @dev This is the core normalization test. Without decimal normalization, _totalBorrowedFrom would treat
+    /// the 6-decimal TOKEN amount as if it were in 18 decimals, making it ~10^12 times too small.
+    function test_mixedDecimals_borrowFromTokenSource_normalizedCorrectly() public {
+        _deployMixedDecimalRevnet();
+
+        // Pay with TOKEN to get project tokens AND create TOKEN surplus in the terminal.
+        // Using TOKEN (not ETH) ensures the borrowable amount from TOKEN source stays within
+        // the terminal's actual TOKEN balance.
+        deal(address(TOKEN), USER, 2_000_000e6);
+        vm.prank(USER);
+        TOKEN.approve(address(jbMultiTerminal()), type(uint256).max);
+        vm.prank(USER);
+        uint256 tokenCount = jbMultiTerminal().pay(MIXED_REVNET_ID, address(TOKEN), 1_000_000e6, USER, 0, "", "");
+        require(tokenCount > 0, "Must receive project tokens");
+
+        // Record borrowable BEFORE any borrow (queried in 18-decimal ETH context).
+        uint256 smallCollateral = tokenCount / 10;
+        uint256 borrowableBefore = LOANS_CONTRACT.borrowableAmountFrom(MIXED_REVNET_ID, smallCollateral, 18, uint32(uint160(JBConstants.NATIVE_TOKEN)));
+        assertTrue(borrowableBefore > 0, "Must have borrowable amount before borrow");
+
+        // Borrow from TOKEN source using a small portion of collateral.
+        mockExpect(address(jbPermissions()), abi.encodeCall(IJBPermissions.hasPermission, (address(LOANS_CONTRACT), USER, MIXED_REVNET_ID, 10, true, true)), abi.encode(true));
+        REVLoanSource memory tokenSource = REVLoanSource({token: address(TOKEN), terminal: jbMultiTerminal()});
+        vm.prank(USER);
+        (uint256 loanId, REVLoan memory loan) = LOANS_CONTRACT.borrowFrom(MIXED_REVNET_ID, tokenSource, 0, smallCollateral, payable(USER), 25);
+
+        assertTrue(loanId != 0, "TOKEN loan should be created");
+        assertTrue(loan.amount > 0, "Loan amount should be nonzero");
+
+        // Verify totalBorrowedFrom tracks the raw 6-decimal amount.
+        uint256 tokenBorrowed = LOANS_CONTRACT.totalBorrowedFrom(MIXED_REVNET_ID, jbMultiTerminal(), address(TOKEN));
+        assertEq(tokenBorrowed, loan.amount, "totalBorrowedFrom should match loan amount in source decimals");
+
+        // Query borrowable for more collateral in 18-decimal ETH context.
+        // This calls _totalBorrowedFrom which must normalize the 6-dec TOKEN amount to 18-dec.
+        // Without normalization: TOKEN borrow treated as near-zero → borrowable barely changes.
+        // With normalization: TOKEN borrow properly scaled → borrowable reflects the outstanding debt.
+        uint256 borrowableAfter = LOANS_CONTRACT.borrowableAmountFrom(MIXED_REVNET_ID, smallCollateral, 18, uint32(uint160(JBConstants.NATIVE_TOKEN)));
+
+        // borrowableAfter should still be nonzero (the revnet has surplus).
+        assertTrue(borrowableAfter > 0, "Should still have borrowable amount after TOKEN borrow");
+
+        // Also query in TOKEN's own 6-decimal context to verify the same-currency normalization path.
+        // Since only TOKEN source has borrows and ETH source has 0 (skipped via `continue`), this is safe.
+        uint256 borrowableInToken = LOANS_CONTRACT.borrowableAmountFrom(MIXED_REVNET_ID, smallCollateral, 6, uint32(uint160(address(TOKEN))));
+        assertTrue(borrowableInToken > 0, "Borrowable in TOKEN terms should be nonzero");
+    }
+
+    /// @notice Borrow from both ETH and TOKEN sources, verify both borrows are tracked and aggregated.
+    /// @dev TOKEN borrow MUST happen first: when borrowing from TOKEN source, _totalBorrowedFrom is queried
+    /// in 6-dec TOKEN context. If ETH had borrows, converting ETH→TOKEN at 6 decimals causes the inverse
+    /// price feed to truncate to 0 (mulDiv(1e6,1e6,1e21)=0). Borrowing TOKEN first ensures ETH=0→continue.
+    /// The subsequent ETH borrow then exercises cross-decimal normalization (TOKEN 6-dec → ETH 18-dec) using
+    /// the DIRECT TOKEN→ETH feed which works at 18 decimals.
+    function test_mixedDecimals_borrowFromBothSources_aggregatesCorrectly() public {
+        _deployMixedDecimalRevnet();
+
+        // STEP 1: Pay TOKEN ONLY to get project tokens and create TOKEN-only surplus.
+        // This avoids ETH surplus inflating the TOKEN borrowable beyond the terminal's TOKEN balance.
+        deal(address(TOKEN), USER, 10_000_000e6);
+        vm.prank(USER);
+        TOKEN.approve(address(jbMultiTerminal()), type(uint256).max);
+        vm.prank(USER);
+        uint256 tokenTokenCount = jbMultiTerminal().pay(MIXED_REVNET_ID, address(TOKEN), 5_000_000e6, USER, 0, "", "");
+
+        // STEP 2: Borrow from TOKEN source (ETH totalBorrowed=0 → skipped via `continue`, no inverse price needed).
+        uint256 smallCollateral = tokenTokenCount / 20;
+        mockExpect(address(jbPermissions()), abi.encodeCall(IJBPermissions.hasPermission, (address(LOANS_CONTRACT), USER, MIXED_REVNET_ID, 10, true, true)), abi.encode(true));
+        REVLoanSource memory tokenSource = REVLoanSource({token: address(TOKEN), terminal: jbMultiTerminal()});
+        vm.prank(USER);
+        (uint256 tokenLoanId,) = LOANS_CONTRACT.borrowFrom(MIXED_REVNET_ID, tokenSource, 0, smallCollateral, payable(USER), 25);
+        assertTrue(tokenLoanId != 0, "TOKEN loan should be created");
+
+        // STEP 3: Pay ETH to create ETH surplus.
+        vm.prank(USER);
+        uint256 ethTokenCount = jbMultiTerminal().pay{value: 10e18}(MIXED_REVNET_ID, JBConstants.NATIVE_TOKEN, 10e18, USER, 0, "", "");
+
+        // STEP 4: Borrow from ETH source. Now _totalBorrowedFrom(revnetId, 18, ETH_CURRENCY) must normalize
+        // the TOKEN borrow (6 dec) to 18 dec using the DIRECT TOKEN→ETH feed. This is the key normalization test.
+        uint256 ethCollateral = ethTokenCount / 20;
+        mockExpect(address(jbPermissions()), abi.encodeCall(IJBPermissions.hasPermission, (address(LOANS_CONTRACT), USER, MIXED_REVNET_ID, 10, true, true)), abi.encode(true));
+        REVLoanSource memory ethSource = REVLoanSource({token: JBConstants.NATIVE_TOKEN, terminal: jbMultiTerminal()});
+        vm.prank(USER);
+        (uint256 ethLoanId,) = LOANS_CONTRACT.borrowFrom(MIXED_REVNET_ID, ethSource, 0, ethCollateral, payable(USER), 25);
+        assertTrue(ethLoanId != 0, "ETH loan should be created");
+
+        // Both sources should have tracked borrows.
+        uint256 ethBorrowed = LOANS_CONTRACT.totalBorrowedFrom(MIXED_REVNET_ID, jbMultiTerminal(), JBConstants.NATIVE_TOKEN);
+        uint256 tokenBorrowed = LOANS_CONTRACT.totalBorrowedFrom(MIXED_REVNET_ID, jbMultiTerminal(), address(TOKEN));
+        assertTrue(ethBorrowed > 0, "ETH borrow should be tracked");
+        assertTrue(tokenBorrowed > 0, "TOKEN borrow should be tracked");
+
+        // The total number of loans should be 2.
+        assertEq(LOANS_CONTRACT.numberOfLoansFor(MIXED_REVNET_ID), 2, "Should have 2 loans");
+
+        // Query borrowable in 18-decimal ETH context. This exercises _totalBorrowedFrom's
+        // cross-decimal normalization: TOKEN borrows (6 dec) must be normalized to 18 dec before
+        // aggregation with the direct TOKEN→ETH price feed.
+        uint256 borrowableInEth = LOANS_CONTRACT.borrowableAmountFrom(MIXED_REVNET_ID, ethCollateral, 18, uint32(uint160(JBConstants.NATIVE_TOKEN)));
+        assertTrue(borrowableInEth > 0, "Should still have borrowable after both borrows (18-dec ETH)");
+    }
 }

--- a/test/TestPR32_MixedFixes.t.sol
+++ b/test/TestPR32_MixedFixes.t.sol
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.23;
+
+import "forge-std/Test.sol";
+import /* {*} from */ "@bananapus/core-v5/test/helpers/TestBaseWorkflow.sol";
+import /* {*} from "@bananapus/721-hook-v5/src/JB721TiersHookDeployer.sol";
+    import /* {*} from */ "./../src/REVDeployer.sol";
+import "@croptop/core-v5/src/CTPublisher.sol";
+import "@bananapus/core-v5/script/helpers/CoreDeploymentLib.sol";
+import "@bananapus/721-hook-v5/script/helpers/Hook721DeploymentLib.sol";
+import "@bananapus/suckers-v5/script/helpers/SuckerDeploymentLib.sol";
+import "@croptop/core-v5/script/helpers/CroptopDeploymentLib.sol";
+import "@bananapus/swap-terminal-v5/script/helpers/SwapTerminalDeploymentLib.sol";
+import "@bananapus/buyback-hook-v5/script/helpers/BuybackDeploymentLib.sol";
+import {JBConstants} from "@bananapus/core-v5/src/libraries/JBConstants.sol";
+import {JBAccountingContext} from "@bananapus/core-v5/src/structs/JBAccountingContext.sol";
+import {MockPriceFeed} from "@bananapus/core-v5/test/mock/MockPriceFeed.sol";
+import {MockERC20} from "@bananapus/core-v5/test/mock/MockERC20.sol";
+import {REVLoans} from "../src/REVLoans.sol";
+import {REVLoan} from "../src/structs/REVLoan.sol";
+import {REVStageConfig, REVAutoIssuance} from "../src/structs/REVStageConfig.sol";
+import {REVLoanSource} from "../src/structs/REVLoanSource.sol";
+import {REVDescription} from "../src/structs/REVDescription.sol";
+import {REVBuybackPoolConfig} from "../src/structs/REVBuybackPoolConfig.sol";
+import {IREVLoans} from "./../src/interfaces/IREVLoans.sol";
+import {JBSuckerDeployerConfig} from "@bananapus/suckers-v5/src/structs/JBSuckerDeployerConfig.sol";
+import {JBSuckerRegistry} from "@bananapus/suckers-v5/src/JBSuckerRegistry.sol";
+import {JB721TiersHookDeployer} from "@bananapus/721-hook-v5/src/JB721TiersHookDeployer.sol";
+import {JB721TiersHook} from "@bananapus/721-hook-v5/src/JB721TiersHook.sol";
+import {JB721TiersHookStore} from "@bananapus/721-hook-v5/src/JB721TiersHookStore.sol";
+import {JBAddressRegistry} from "@bananapus/address-registry-v5/src/JBAddressRegistry.sol";
+import {IJBAddressRegistry} from "@bananapus/address-registry-v5/src/interfaces/IJBAddressRegistry.sol";
+
+/// @notice Tests for PR #32: liquidation boundary, reallocate msg.value, and decimal normalization fixes.
+contract TestPR32_MixedFixes is TestBaseWorkflow, JBTest {
+    bytes32 REV_DEPLOYER_SALT = "REVDeployer";
+
+    REVDeployer REV_DEPLOYER;
+    JB721TiersHook EXAMPLE_HOOK;
+    IJB721TiersHookDeployer HOOK_DEPLOYER;
+    IJB721TiersHookStore HOOK_STORE;
+    IJBAddressRegistry ADDRESS_REGISTRY;
+    REVLoans LOANS_CONTRACT;
+    MockERC20 TOKEN;
+    IJBSuckerRegistry SUCKER_REGISTRY;
+    CTPublisher PUBLISHER;
+
+    uint256 FEE_PROJECT_ID;
+    uint256 REVNET_ID;
+
+    address USER = makeAddr("user");
+
+    address private constant TRUSTED_FORWARDER = 0xB2b5841DBeF766d4b521221732F9B618fCf34A87;
+
+    function setUp() public override {
+        super.setUp();
+        FEE_PROJECT_ID = jbProjects().createFor(multisig());
+        SUCKER_REGISTRY = new JBSuckerRegistry(jbDirectory(), jbPermissions(), multisig(), address(0));
+        HOOK_STORE = new JB721TiersHookStore();
+        EXAMPLE_HOOK = new JB721TiersHook(jbDirectory(), jbPermissions(), jbRulesets(), HOOK_STORE, multisig());
+        ADDRESS_REGISTRY = new JBAddressRegistry();
+        HOOK_DEPLOYER = new JB721TiersHookDeployer(EXAMPLE_HOOK, HOOK_STORE, ADDRESS_REGISTRY, multisig());
+        PUBLISHER = new CTPublisher(jbDirectory(), jbPermissions(), FEE_PROJECT_ID, multisig());
+        TOKEN = new MockERC20("1/2 ETH", "1/2");
+        MockPriceFeed priceFeed = new MockPriceFeed(1e21, 6);
+        vm.prank(multisig());
+        jbPrices().addPriceFeedFor(0, uint32(uint160(address(TOKEN))), uint32(uint160(JBConstants.NATIVE_TOKEN)), priceFeed);
+        REV_DEPLOYER = new REVDeployer{salt: REV_DEPLOYER_SALT}(jbController(), SUCKER_REGISTRY, FEE_PROJECT_ID, HOOK_DEPLOYER, PUBLISHER, TRUSTED_FORWARDER);
+        LOANS_CONTRACT = new REVLoans({revnets: REV_DEPLOYER, revId: FEE_PROJECT_ID, owner: address(this), permit2: permit2(), trustedForwarder: TRUSTED_FORWARDER});
+        vm.prank(multisig());
+        jbProjects().approve(address(REV_DEPLOYER), FEE_PROJECT_ID);
+        _deployFeeProject();
+        _deployRevnet();
+        vm.deal(USER, 1000e18);
+    }
+
+    function _deployFeeProject() internal {
+        JBAccountingContext[] memory acc = new JBAccountingContext[](2);
+        acc[0] = JBAccountingContext({token: JBConstants.NATIVE_TOKEN, decimals: 18, currency: uint32(uint160(JBConstants.NATIVE_TOKEN))});
+        acc[1] = JBAccountingContext({token: address(TOKEN), decimals: 6, currency: uint32(uint160(address(TOKEN)))});
+        JBTerminalConfig[] memory tc = new JBTerminalConfig[](1);
+        tc[0] = JBTerminalConfig({terminal: jbMultiTerminal(), accountingContextsToAccept: acc});
+        REVStageConfig[] memory stages = new REVStageConfig[](1);
+        JBSplit[] memory splits = new JBSplit[](1);
+        splits[0].beneficiary = payable(multisig());
+        splits[0].percent = 10_000;
+        REVAutoIssuance[] memory ai = new REVAutoIssuance[](1);
+        ai[0] = REVAutoIssuance({chainId: uint32(block.chainid), count: uint104(70_000e18), beneficiary: multisig()});
+        stages[0] = REVStageConfig({startsAtOrAfter: uint40(block.timestamp), autoIssuances: ai, splitPercent: 2000, splits: splits, initialIssuance: uint112(1000e18), issuanceCutFrequency: 90 days, issuanceCutPercent: JBConstants.MAX_WEIGHT_CUT_PERCENT / 2, cashOutTaxRate: 6000, extraMetadata: 0});
+        REVConfig memory cfg = REVConfig({description: REVDescription("Revnet", "$REV", "ipfs://test", "REV_TOKEN"), baseCurrency: uint32(uint160(JBConstants.NATIVE_TOKEN)), splitOperator: multisig(), stageConfigurations: stages, loanSources: new REVLoanSource[](0), loans: address(0)});
+        REVBuybackHookConfig memory bbh = REVBuybackHookConfig({dataHook: IJBRulesetDataHook(address(0)), hookToConfigure: IJBBuybackHook(address(0)), poolConfigurations: new REVBuybackPoolConfig[](0)});
+        vm.prank(multisig());
+        REV_DEPLOYER.deployFor({revnetId: FEE_PROJECT_ID, configuration: cfg, terminalConfigurations: tc, buybackHookConfiguration: bbh, suckerDeploymentConfiguration: REVSuckerDeploymentConfig({deployerConfigurations: new JBSuckerDeployerConfig[](0), salt: keccak256("FEE")})});
+    }
+
+    function _deployRevnet() internal {
+        JBAccountingContext[] memory acc = new JBAccountingContext[](2);
+        acc[0] = JBAccountingContext({token: JBConstants.NATIVE_TOKEN, decimals: 18, currency: uint32(uint160(JBConstants.NATIVE_TOKEN))});
+        acc[1] = JBAccountingContext({token: address(TOKEN), decimals: 6, currency: uint32(uint160(address(TOKEN)))});
+        JBTerminalConfig[] memory tc = new JBTerminalConfig[](1);
+        tc[0] = JBTerminalConfig({terminal: jbMultiTerminal(), accountingContextsToAccept: acc});
+        REVStageConfig[] memory stages = new REVStageConfig[](1);
+        JBSplit[] memory splits = new JBSplit[](1);
+        splits[0].beneficiary = payable(multisig());
+        splits[0].percent = 10_000;
+        REVAutoIssuance[] memory ai = new REVAutoIssuance[](1);
+        ai[0] = REVAutoIssuance({chainId: uint32(block.chainid), count: uint104(70_000e18), beneficiary: multisig()});
+        stages[0] = REVStageConfig({startsAtOrAfter: uint40(block.timestamp), autoIssuances: ai, splitPercent: 2000, splits: splits, initialIssuance: uint112(1000e18), issuanceCutFrequency: 90 days, issuanceCutPercent: JBConstants.MAX_WEIGHT_CUT_PERCENT / 2, cashOutTaxRate: 6000, extraMetadata: 0});
+        REVLoanSource[] memory ls = new REVLoanSource[](1);
+        ls[0] = REVLoanSource({token: JBConstants.NATIVE_TOKEN, terminal: jbMultiTerminal()});
+        REVConfig memory cfg = REVConfig({description: REVDescription("NANA", "$NANA", "ipfs://test2", "NANA_TOKEN"), baseCurrency: uint32(uint160(JBConstants.NATIVE_TOKEN)), splitOperator: multisig(), stageConfigurations: stages, loanSources: ls, loans: address(LOANS_CONTRACT)});
+        REVBuybackHookConfig memory bbh = REVBuybackHookConfig({dataHook: IJBRulesetDataHook(address(0)), hookToConfigure: IJBBuybackHook(address(0)), poolConfigurations: new REVBuybackPoolConfig[](0)});
+        REVNET_ID = REV_DEPLOYER.deployFor({revnetId: 0, configuration: cfg, terminalConfigurations: tc, buybackHookConfiguration: bbh, suckerDeploymentConfiguration: REVSuckerDeploymentConfig({deployerConfigurations: new JBSuckerDeployerConfig[](0), salt: keccak256("NANA")})});
+    }
+
+    function _setupLoan(address user, uint256 ethAmount, uint256 prepaidFee) internal returns (uint256 loanId, uint256 tokenCount, uint256 borrowAmount) {
+        vm.prank(user);
+        tokenCount = jbMultiTerminal().pay{value: ethAmount}(REVNET_ID, JBConstants.NATIVE_TOKEN, ethAmount, user, 0, "", "");
+        borrowAmount = LOANS_CONTRACT.borrowableAmountFrom(REVNET_ID, tokenCount, 18, uint32(uint160(JBConstants.NATIVE_TOKEN)));
+        if (borrowAmount == 0) return (0, tokenCount, 0);
+        mockExpect(address(jbPermissions()), abi.encodeCall(IJBPermissions.hasPermission, (address(LOANS_CONTRACT), user, REVNET_ID, 10, true, true)), abi.encode(true));
+        REVLoanSource memory source = REVLoanSource({token: JBConstants.NATIVE_TOKEN, terminal: jbMultiTerminal()});
+        vm.prank(user);
+        (loanId,) = LOANS_CONTRACT.borrowFrom(REVNET_ID, source, 0, tokenCount, payable(user), prepaidFee);
+    }
+
+    /// @notice At exactly LOAN_LIQUIDATION_DURATION, determineSourceFeeAmount should revert with LoanExpired (>= boundary).
+    function test_liquidationBoundary_exactDuration_isLiquidatable() public {
+        (uint256 loanId,,) = _setupLoan(USER, 10e18, 25);
+        require(loanId != 0, "Loan setup failed");
+
+        REVLoan memory loan = LOANS_CONTRACT.loanOf(loanId);
+
+        // Warp to exactly LOAN_LIQUIDATION_DURATION after creation
+        vm.warp(loan.createdAt + LOANS_CONTRACT.LOAN_LIQUIDATION_DURATION());
+
+        // With the >= fix, this should revert because timeSinceLoanCreated == LOAN_LIQUIDATION_DURATION
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                REVLoans.REVLoans_LoanExpired.selector,
+                LOANS_CONTRACT.LOAN_LIQUIDATION_DURATION(),
+                LOANS_CONTRACT.LOAN_LIQUIDATION_DURATION()
+            )
+        );
+        LOANS_CONTRACT.determineSourceFeeAmount(loan, loan.amount);
+    }
+
+    /// @notice At LOAN_LIQUIDATION_DURATION - 1, the loan should still be manageable (not expired).
+    function test_liquidationBoundary_oneBefore_notLiquidatable() public {
+        (uint256 loanId,,) = _setupLoan(USER, 10e18, 25);
+        require(loanId != 0, "Loan setup failed");
+
+        REVLoan memory loan = LOANS_CONTRACT.loanOf(loanId);
+
+        // Warp to one second before the liquidation boundary
+        vm.warp(loan.createdAt + LOANS_CONTRACT.LOAN_LIQUIDATION_DURATION() - 1);
+
+        // This should NOT revert — the loan is still within the liquidation window
+        uint256 fee = LOANS_CONTRACT.determineSourceFeeAmount(loan, loan.amount);
+
+        // Fee should be > 0 since we're past the prepaid duration but before liquidation
+        assertTrue(fee > 0, "Fee should be nonzero for a loan past its prepaid period");
+    }
+
+    /// @notice Sending ETH to the non-payable reallocateCollateralFromLoan should revert.
+    /// @dev Since the function is not payable, Solidity prevents sending ETH at compile time.
+    /// We use a low-level call to bypass this and verify the EVM-level revert.
+    function test_reallocate_withETHValue_reverts() public {
+        (uint256 loanId, uint256 tokenCount,) = _setupLoan(USER, 10e18, 25);
+        require(loanId != 0, "Loan setup failed");
+
+        // Encode the function call
+        bytes memory callData = abi.encodeWithSelector(
+            LOANS_CONTRACT.reallocateCollateralFromLoan.selector,
+            loanId,
+            tokenCount / 10,
+            REVLoanSource({token: JBConstants.NATIVE_TOKEN, terminal: jbMultiTerminal()}),
+            0,
+            0,
+            USER,
+            25
+        );
+
+        // Low-level call with msg.value to bypass Solidity's payable check
+        vm.prank(USER);
+        (bool success,) = address(LOANS_CONTRACT).call{value: 1 ether}(callData);
+        assertFalse(success, "Sending ETH to non-payable reallocate should revert");
+    }
+
+    /// @notice Calling reallocateCollateralFromLoan without ETH should work (given valid params).
+    function test_reallocate_withoutETHValue_succeeds() public {
+        (uint256 loanId, uint256 tokenCount,) = _setupLoan(USER, 10e18, 25);
+        require(loanId != 0, "Loan setup failed");
+
+        // Inflate surplus so collateral removal is viable
+        address donor = makeAddr("donor");
+        vm.deal(donor, 500e18);
+        vm.prank(donor);
+        jbMultiTerminal().addToBalanceOf{value: 500e18}(REVNET_ID, JBConstants.NATIVE_TOKEN, 500e18, false, "", "");
+
+        // Get extra tokens to add as collateral to the new loan
+        vm.prank(USER);
+        uint256 extraTokens = jbMultiTerminal().pay{value: 50e18}(REVNET_ID, JBConstants.NATIVE_TOKEN, 50e18, USER, 0, "", "");
+
+        uint256 collateralToTransfer = tokenCount / 10;
+
+        REVLoanSource memory source = REVLoanSource({token: JBConstants.NATIVE_TOKEN, terminal: jbMultiTerminal()});
+
+        // Mock burn permission
+        mockExpect(address(jbPermissions()), abi.encodeCall(IJBPermissions.hasPermission, (address(LOANS_CONTRACT), USER, REVNET_ID, 10, true, true)), abi.encode(true));
+
+        // Call without msg.value — should succeed
+        vm.prank(USER);
+        (uint256 reallocatedLoanId, uint256 newLoanId,,) = LOANS_CONTRACT.reallocateCollateralFromLoan(
+            loanId,
+            collateralToTransfer,
+            source,
+            0,
+            extraTokens,
+            payable(USER),
+            25
+        );
+
+        assertTrue(reallocatedLoanId != 0, "Reallocated loan should exist");
+        assertTrue(newLoanId != 0, "New loan should exist");
+    }
+}


### PR DESCRIPTION
…payable removal

- Normalize token amounts by decimal difference in _totalBorrowedFrom before aggregating across different token decimals
- Change liquidation threshold from > to >= for LOAN_LIQUIDATION_DURATION
- Remove payable from reallocateCollateralFromLoan and reject msg.value since the function only moves existing collateral

# Description

*What does this PR: do, how, why?*

## Limitations & risks

*Are there any trade-off or new vulnarbility surface based on theses changes?*

# Check-list
- [ ] Tests are covering the new feature
- [ ] Code is [natspec'd](https://docs.soliditylang.org/en/v0.8.17/natspec-format.html)
- [ ] Code is [linted and formatted](https://docs.soliditylang.org/en/v0.8.17/style-guide.html)
- [ ] I have run the test locally (and they pass)
- [ ] I have rebased to the latest main commit (and tests still pass)

# Interactions
These changes will impact the following contracts:
- Directly:

- Indirectly: