### PR TITLE
fix: align IREVLoans argument names with implementation

### DIFF
--- a/src/interfaces/IREVLoans.sol
+++ b/src/interfaces/IREVLoans.sol
@@ -63,7 +63,7 @@ interface IREVLoans {
 
     function borrowableAmountFrom(
         uint256 revnetId,
-        uint256 collateral,
+        uint256 collateralCount,
         uint256 decimals,
         uint256 currency
     )
@@ -97,12 +97,12 @@ interface IREVLoans {
         uint256 revnetId,
         REVLoanSource calldata source,
         uint256 minBorrowAmount,
-        uint256 collateral,
+        uint256 collateralCount,
         address payable beneficiary,
         uint256 prepaidFeePercent
     )
         external
-        returns (uint256 loanId, REVLoan memory loan);
+        returns (uint256 loanId, REVLoan memory);
     function liquidateExpiredLoansFrom(uint256 revnetId, uint256 startingLoanId, uint256 count) external;
     function repayLoan(
         uint256 loanId,
@@ -113,13 +113,13 @@ interface IREVLoans {
     )
         external
         payable
-        returns (uint256 paidOffLoanId, REVLoan memory loan);
+        returns (uint256 paidOffLoanId, REVLoan memory paidOffloan);
     function reallocateCollateralFromLoan(
         uint256 loanId,
-        uint256 collateralToTransfer,
+        uint256 collateralCountToTransfer,
         REVLoanSource calldata source,
         uint256 minBorrowAmount,
-        uint256 collateralToAdd,
+        uint256 collateralCountToAdd,
         address payable beneficiary,
         uint256 prepaidFeePercent
     )

--- a/test/REVLoansSourced.t.sol
+++ b/test/REVLoansSourced.t.sol
@@ -701,7 +701,7 @@ contract REVLoansSourcedTests is TestBaseWorkflow, JBTest {
 
         uint256 fullReclaimableSurplus = jbMultiTerminal().STORE().currentReclaimableSurplusOf({
             projectId: revnetProjectId,
-            tokenCount: tokensToCashout,
+            cashOutCount: tokensToCashout,
             totalSupply: totalSupplyExcludingAutoMint,
             surplus: nativeSurplus
         });
@@ -713,7 +713,7 @@ contract REVLoansSourcedTests is TestBaseWorkflow, JBTest {
 
         uint256 reclaimableSurplus = jbMultiTerminal().STORE().currentReclaimableSurplusOf({
             projectId: revnetProjectId,
-            tokenCount: tokensToCashout - feeTokenCount,
+            cashOutCount: tokensToCashout - feeTokenCount,
             totalSupply: totalSupplyExcludingAutoMint,
             surplus: nativeSurplus
         });
@@ -725,7 +725,7 @@ contract REVLoansSourcedTests is TestBaseWorkflow, JBTest {
 
         uint256 revFee = jbMultiTerminal().STORE().currentReclaimableSurplusOf({
             projectId: revnetProjectId,
-            tokenCount: feeTokenCount,
+            cashOutCount: feeTokenCount,
             totalSupply: totalSupplyExcludingAutoMint - (tokensToCashout - feeTokenCount),
             surplus: nativeSurplus
         });


### PR DESCRIPTION
Fixes collateral→collateralCount and return value name mismatches in borrowableAmountFrom, borrowFrom, repayLoan, and reallocateCollateralFromLoan.

# Description

*What does this PR: do, how, why?*

## Limitations & risks

*Are there any trade-off or new vulnarbility surface based on theses changes?*

# Check-list
- [ ] Tests are covering the new feature
- [ ] Code is [natspec'd](https://docs.soliditylang.org/en/v0.8.17/natspec-format.html)
- [ ] Code is [linted and formatted](https://docs.soliditylang.org/en/v0.8.17/style-guide.html)
- [ ] I have run the test locally (and they pass)
- [ ] I have rebased to the latest main commit (and tests still pass)

# Interactions
These changes will impact the following contracts:
- Directly:

- Indirectly: