### PR TITLE
Add Celo mainnet sucker deployer config for fee project

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -21,6 +21,8 @@ ethereum_sepolia ="${RPC_ETHEREUM_SEPOLIA}"
 optimism_sepolia = "${RPC_OPTIMISM_SEPOLIA}"
 polygon_mumbai = "${RPC_POLYGON_MUMBAI}"
 base_sepolia = "${RPC_BASE_SEPOLIA}"
+celo = "${RPC_CELO_MAINNET}"
+celo_sepolia = "${RPC_CELO_SEPOLIA}"
 
 [profile.ci_sizes]
 optimizer_runs = 550 

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -79,8 +79,8 @@ contract DeployScript is Script, Sphinx {
     function configureSphinx() public override {
         // TODO: Update to contain revnet devs.
         sphinxConfig.projectName = "revnet-core-v5";
-        sphinxConfig.mainnets = ["ethereum", "optimism", "base", "arbitrum"];
-        sphinxConfig.testnets = ["ethereum_sepolia", "optimism_sepolia", "base_sepolia", "arbitrum_sepolia"];
+        sphinxConfig.mainnets = ["ethereum", "optimism", "base", "arbitrum", "celo"];
+        sphinxConfig.testnets = ["ethereum_sepolia", "optimism_sepolia", "base_sepolia", "arbitrum_sepolia", "celo_sepolia"];
     }
 
     function run() public {
@@ -263,6 +263,15 @@ contract DeployScript is Script, Sphinx {
 
                 suckerDeployerConfigurations[2] =
                     JBSuckerDeployerConfig({deployer: suckers.arbitrumDeployer, mappings: tokenMappings});
+            } else if (block.chainid == 42_220) {
+                // Celo Mainnet -> L1 (via CCIP). CCIP not available on Celo Sepolia.
+                suckerDeployerConfigurations = new JBSuckerDeployerConfig[](1);
+                suckerDeployerConfigurations[0] =
+                    JBSuckerDeployerConfig({deployer: suckers.celoDeployer, mappings: tokenMappings});
+
+                if (address(suckerDeployerConfigurations[0].deployer) == address(0)) {
+                    revert("Celo > L1 CCIP Sucker is not configured");
+                }
             } else {
                 suckerDeployerConfigurations = new JBSuckerDeployerConfig[](1);
                 // L2 -> Mainnet


### PR DESCRIPTION
Celo uses CCIP sucker deployer (mainnet only — CCIP not on Celo Sepolia).

# Description

*What does this PR: do, how, why?*

## Limitations & risks

*Are there any trade-off or new vulnarbility surface based on theses changes?*

# Check-list
- [ ] Tests are covering the new feature
- [ ] Code is [natspec'd](https://docs.soliditylang.org/en/v0.8.17/natspec-format.html)
- [ ] Code is [linted and formatted](https://docs.soliditylang.org/en/v0.8.17/style-guide.html)
- [ ] I have run the test locally (and they pass)
- [ ] I have rebased to the latest main commit (and tests still pass)

# Interactions
These changes will impact the following contracts:
- Directly:

- Indirectly: