### PR TITLE
Fix vm_version typo to evm_version in foundry.toml

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,6 +1,6 @@
 [profile.default]
 solc = '0.8.23'
-vm_version = 'paris'                   # Required for L2s (Optimism, Arbitrum, etc.)
+evm_version = 'paris'                   # Required for L2s (Optimism, Arbitrum, etc.)
 sizes = true
 optimizer_runs = 150
 block_number = 14126430


### PR DESCRIPTION
Foundry's correct key is evm_version. vm_version is silently ignored, meaning EVM version was not being enforced.

# Description

*What does this PR: do, how, why?*

## Limitations & risks

*Are there any trade-off or new vulnarbility surface based on theses changes?*

# Check-list
- [ ] Tests are covering the new feature
- [ ] Code is [natspec'd](https://docs.soliditylang.org/en/v0.8.17/natspec-format.html)
- [ ] Code is [linted and formatted](https://docs.soliditylang.org/en/v0.8.17/style-guide.html)
- [ ] I have run the test locally (and they pass)
- [ ] I have rebased to the latest main commit (and tests still pass)

# Interactions
These changes will impact the following contracts:
- Directly:

- Indirectly: