### PR TITLE
Add maximumSplitPercent to REVCroptopAllowedPost

### DIFF
--- a/src/REVDeployer.sol
+++ b/src/REVDeployer.sol
@@ -917,6 +917,7 @@ contract REVDeployer is ERC2771Context, IREVDeployer, IJBRulesetDataHook, IJBCas
                     minimumPrice: post.minimumPrice,
                     minimumTotalSupply: post.minimumTotalSupply,
                     maximumTotalSupply: post.maximumTotalSupply,
+                    maximumSplitPercent: post.maximumSplitPercent,
                     allowedAddresses: post.allowedAddresses
                 });
             }

--- a/src/structs/REVCroptopAllowedPost.sol
+++ b/src/structs/REVCroptopAllowedPost.sol
@@ -7,11 +7,14 @@ pragma solidity ^0.8.0;
 /// @custom:member minimumTotalSupply The minimum total supply of NFTs that can be made available when minting.
 /// @custom:member maxTotalSupply The max total supply of NFTs that can be made available when minting. Leave as 0 for
 /// max.
+/// @custom:member maximumSplitPercent The maximum split percent (out of JBConstants.SPLITS_TOTAL_PERCENT) that a
+/// poster can set. 0 means splits are not allowed.
 /// @custom:member allowedAddresses A list of addresses that are allowed to post on the category through Croptop.
 struct REVCroptopAllowedPost {
     uint24 category;
     uint104 minimumPrice;
     uint32 minimumTotalSupply;
     uint32 maximumTotalSupply;
+    uint32 maximumSplitPercent;
     address[] allowedAddresses;
 }


### PR DESCRIPTION
## Summary
- Adds `maximumSplitPercent` field to `REVCroptopAllowedPost` struct
- Passes the field through to `CTAllowedPost` in `REVDeployer._deploy721RevnetFor`
- Aligns with [croptop-core-v5#14](https://github.com/mejango/croptop-core-v5/pull/14) which adds submitter-specified splits within an owner-configured limit

## Context
Croptop now allows post submitters to set custom `splitPercent` and `splits` on their tiers, within a `maximumSplitPercent` set by the project owner per category. This PR updates the revnet deployer to surface that configuration.

## Test plan
- [ ] Verify compilation once 721-hook-v5 and croptop-core-v5 dependencies are updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)